### PR TITLE
Use already existing platform specific defines

### DIFF
--- a/examples/is_file_example.rs
+++ b/examples/is_file_example.rs
@@ -1,16 +1,24 @@
 // Show usage of is_* functions
 use std::{
-    env,
     fs::{self, File},
     io,
 };
 
-use permissions::{is_executable, is_readable, is_removable, is_writable};
+#[cfg(unix)]
+use std::env;
+
+#[cfg(unix)]
+use permissions::is_executable;
+use permissions::{is_readable, is_removable, is_writable};
 
 fn main() -> io::Result<()> {
     // Asserts with files
-    let this_program_path = env::args().next().unwrap();
-    assert!(is_executable(&this_program_path)?);
+
+    #[cfg(unix)]
+    {
+        let this_program_path = env::args().next().unwrap();
+        assert!(is_executable(&this_program_path)?);
+    }
 
     let this_file = "examples/example2.rs";
     assert!(is_readable(&this_file)?);
@@ -28,6 +36,7 @@ fn main() -> io::Result<()> {
     fs::create_dir(temp_directory)?;
     assert!(is_readable(&temp_directory)?);
     assert!(is_writable(&temp_directory)?);
+    #[cfg(unix)]
     assert!(is_executable(&temp_directory)?);
     assert!(is_removable(&temp_directory)?);
     fs::remove_dir(temp_directory)?;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -98,7 +98,7 @@ pub fn is_creatable(path: impl AsRef<Path>) -> io::Result<bool> {
         None => return Ok(false),
         Some(parent) => parent,
     };
-    access_syscall(&parent, libc::W_OK)
+    access_syscall(&parent, consts::W_OK)
 }
 
 /// Check if current process has permission to read.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //!    assert!(is_readable("src/")?);
 //!    assert!(is_writable("src/")?);
 //!    assert!(is_writable("src/lib.rs")?);
+//!    #[cfg(unix)]
 //!    assert!(is_executable("/usr/bin/cat")?);
 //!    assert!(is_removable("src/lib.rs")?);
 //!    assert!(is_creatable("src/file.rs")?);


### PR DESCRIPTION
This fixes #4. The values were already defined, so I only changed the code to actually use it.

I also updated the test code so it works under windows.